### PR TITLE
Removing references to bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 `<div style="height: 50px"><img style="float:right" alt="Vantiq Logo" src="http://vantiq.com/wp-content/uploads/2015/12/vantiq.png"/></div>
 
 [![Build Status](https://travis-ci.org/Vantiq/vantiq-sdk-java.svg?branch=master)](https://travis-ci.org/Vantiq/vantiq-sdk-java)
-[ ![Download](https://api.bintray.com/packages/vantiq/maven/vantiq-sdk/images/download.svg) ](https://bintray.com/vantiq/maven/vantiq-sdk/_latestVersion)
 
 # Vantiq SDK for Java
 
@@ -9,15 +8,13 @@ The [Vantiq](http://www.vantiq.com) Java SDK is a Java library that provides an 
 
 ## Installation
 
-The SDK is published through the Bintray Maven repository.  To include this into
+The SDK is published through the Maven Central repository.  To include this into
 your project, you can add the dependency.
 
 In Gradle,
 
     repositories {
-        maven {
-            url "https://dl.bintray.com/vantiq/maven"
-        }
+        mavenCentral()
     }
     
     dependencies {
@@ -25,13 +22,6 @@ In Gradle,
     }
 
 In Maven,
-
-    <repositories>
-        <repository>
-            <id>Vantiq Maven Repo</id>
-            <url>https://dl.bintray.com/vantiq/maven</url>
-        </repository>
-    </repositories>
     
     <dependencies>
         <dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ uploadArchives {
                 name 'Vantiq Java SDK'
                 packaging 'jar'
                 description 'Vantiq SDK for Java and Android'
-                url 'https://github.com/Vantiq/vantiq-sdk-java'
+                url 'https://vantiq.com/'
 
                 scm {
                     url 'https://github.com/Vantiq/vantiq-sdk-java'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+        mavenCentral()
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
@@ -26,7 +29,6 @@ allprojects {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -82,50 +82,55 @@ artifacts {
     archives javadocJar
 }
 
-signing {
-    sign configurations.archives
-}
-
 //
 // Sonatype publishing support
 //
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword') &&
+        rootProject.hasProperty('signing.keyId') && rootProject.hasProperty('signing.password') &&
+        rootProject.hasProperty('signing.secretKeyRingFile')) {
 
-            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
+    signing {
+        sign configurations.archives
+    }
 
-            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-            pom.project {
-                name 'Vantiq Java SDK'
-                packaging 'jar'
-                description 'Vantiq SDK for Java and Android'
-                url 'https://vantiq.com/'
-
-                scm {
-                    url 'https://github.com/Vantiq/vantiq-sdk-java'
-                    connection 'scm:git:git://github.com/Vantiq/vantiq-sdk-java.git'
-                    developerConnection 'scm:git:ssh://git@github.com/Vantiq/vantiq-sdk-java.git'
+                repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(userName: ossrhUsername, password: ossrhPassword)
                 }
 
-                licenses {
-                    license {
-                        name 'MIT License'
-                        url 'https://github.com/Vantiq/vantiq-sdk-java/blob/master/LICENSE'
+                snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+                    authentication(userName: ossrhUsername, password: ossrhPassword)
+                }
+
+                pom.project {
+                    name 'Vantiq Java SDK'
+                    packaging 'jar'
+                    description 'Vantiq SDK for Java and Android'
+                    url 'https://vantiq.com/'
+
+                    scm {
+                        url 'https://github.com/Vantiq/vantiq-sdk-java'
+                        connection 'scm:git:git://github.com/Vantiq/vantiq-sdk-java.git'
+                        developerConnection 'scm:git:ssh://git@github.com/Vantiq/vantiq-sdk-java.git'
                     }
-                }
 
-                developers {
-                    developer {
-                        id 'vantiq'
-                        name 'Vantiq Development'
-                        email 'ossrh-admin@vantiq.com'
+                    licenses {
+                        license {
+                            name 'MIT License'
+                            url 'https://github.com/Vantiq/vantiq-sdk-java/blob/master/LICENSE'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id 'vantiq'
+                            name 'Vantiq Development'
+                            email 'ossrh-admin@vantiq.com'
+                        }
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1+'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
     }
 }
 
 apply plugin: 'java'
 apply plugin: 'maven'
-apply plugin: 'com.jfrog.bintray'
+apply plugin: 'signing'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 //
@@ -81,35 +80,53 @@ artifacts {
     archives javadocJar
 }
 
+signing {
+    sign configurations.archives
+}
+
 //
-// jCenter publishing support
+// Sonatype publishing support
 //
-bintray {
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-    user = System.getenv('BINTRAY_USER')
-    key  = System.getenv('BINTRAY_API_KEY')
+            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
 
-    configurations = ['archives']
+            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
 
-    publish = false
-    dryRun = false
+            pom.project {
+                name 'Vantiq Java SDK'
+                packaging 'jar'
+                description 'Vantiq SDK for Java and Android'
+                url 'https://github.com/Vantiq/vantiq-sdk-java'
 
-    pkg {
-        userOrg = 'vantiq'
-        repo = 'maven'
-        name = archivesBaseName
-        desc = 'Vantiq SDK for Java and Android'
+                scm {
+                    url 'https://github.com/Vantiq/vantiq-sdk-java'
+                    connection 'scm:git:git://github.com/Vantiq/vantiq-sdk-java.git'
+                    developerConnection 'scm:git:ssh://git@github.com/Vantiq/vantiq-sdk-java.git'
+                }
 
-        websiteUrl      = 'https://github.com/Vantiq/vantiq-sdk-java'
-        issueTrackerUrl = 'https://github.com/Vantiq/vantiq-sdk-java/issues'
-        vcsUrl          = 'https://github.com/Vantiq/vantiq-sdk-java.git'
-        version {
-            vcsTag = version
+                licenses {
+                    license {
+                        name 'MIT License'
+                        url 'https://github.com/Vantiq/vantiq-sdk-java/blob/master/LICENSE'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'vantiq'
+                        name 'Vantiq Development'
+                        email 'ossrh-admin@vantiq.com'
+                    }
+                }
+            }
         }
-
-        licenses = ['MIT']
-
-        githubRepo = 'Vantiq/vantiq-sdk-java'
-        githubReleaseNotesFile = 'README.md'
     }
 }

--- a/examples/JavaProntoClient/build.gradle
+++ b/examples/JavaProntoClient/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.bmuschko.tomcat'
  
 repositories {
     jcenter()
+    mavenCentral()
 }
  
 dependencies {   

--- a/examples/JavaProntoClient/build.gradle
+++ b/examples/JavaProntoClient/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'war'
 apply plugin: 'com.bmuschko.tomcat'
  
 repositories {
-    jcenter()
     mavenCentral()
 }
  
@@ -36,11 +35,6 @@ tomcat {
 }
 
 buildscript {
- 
-    repositories {
-        jcenter()
-    }
- 
     dependencies {
         classpath 'com.bmuschko:gradle-tomcat-plugin:2.5'
     }

--- a/examples/JavaProntoClient/build.gradle
+++ b/examples/JavaProntoClient/build.gradle
@@ -5,11 +5,6 @@ apply plugin: 'com.bmuschko.tomcat'
  
 repositories {
     jcenter()
-    
-    // Used for VANTIQ SDK
-    maven {
-        url "https://dl.bintray.com/vantiq/maven"
-    }
 }
  
 dependencies {   
@@ -26,8 +21,9 @@ dependencies {
            "org.apache.tomcat:tomcat-websocket:${tomcatVersion}"
     
     // Used for VANTIQ SDK
-    compile 'io.vantiq:vantiq-sdk:1.0.17'
-	
+    def vantiqSDKVersion = "1.0.28"
+    compile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
+    
     // Used to setup Java WebSockets
     compile 'javax.websocket:javax.websocket-api:1.1'
 }


### PR DESCRIPTION
Closes #17 

Replacing all references to Bintray with Sonatype/Maven Central in both the `build.gradle` files and the README.