### PR TITLE
Updating OkHttp and Guava

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-`<div style="height: 50px"><img style="float:right" alt="Vantiq Logo" src="http://vantiq.com/wp-content/uploads/2015/12/vantiq.png"/></div>
-
 [![Build Status](https://travis-ci.org/Vantiq/vantiq-sdk-java.svg?branch=master)](https://travis-ci.org/Vantiq/vantiq-sdk-java)
 
 # Vantiq SDK for Java

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In Gradle,
     }
     
     dependencies {
-        compile 'io.vantiq:vantiq-sdk:1.0.28'
+        compile 'io.vantiq:vantiq-sdk:1.0.29'
     }
 
 In Maven,
@@ -25,7 +25,7 @@ In Maven,
         <dependency>
             <groupId>io.vantiq</groupId>
             <artifactId>vantiq-sdk</artifactId>
-            <version>1.0.28</version>
+            <version>1.0.29</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>    

--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,17 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-ws:3.4.1'
-    compile 'com.google.code.gson:gson:2.6.2'
-    compile 'com.google.guava:guava:19.0'
+ext {
+    okhttpVersion = '4.9.1'
+    guavaVersion = '30.1.1-jre'
+}
 
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
+dependencies {
+    compile "com.squareup.okhttp3:okhttp:${okhttpVersion}"
+    compile 'com.google.code.gson:gson:2.6.2'
+    compile "com.google.guava:guava:${guavaVersion}"
+
+    testCompile "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 //
 group            = 'io.vantiq'
 archivesBaseName = 'vantiq-sdk'
-version          = '1.0.28'
+version          = '1.0.29'
 
 allprojects {
     sourceCompatibility = 1.7

--- a/examples/JavaProntoClient/build.gradle
+++ b/examples/JavaProntoClient/build.gradle
@@ -21,7 +21,7 @@ dependencies {
            "org.apache.tomcat:tomcat-websocket:${tomcatVersion}"
     
     // Used for VANTIQ SDK
-    def vantiqSDKVersion = "1.0.28"
+    def vantiqSDKVersion = "1.0.29"
     compile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
     
     // Used to setup Java WebSockets


### PR DESCRIPTION
Closes #19 

Updated OkHttp as well as Guava. This mostly required making changes to accommodate the new WebSocket implementation in the later versions of OkHttp.

All tests are passing, including the Integration Tests that I ran against my local 1.32 server.