### PR TITLE
Add ability to subscribe to service events & associated artifacts & tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 //
 group            = 'io.vantiq'
 archivesBaseName = 'vantiq-sdk'
-version          = '1.0.32'
+version          = '1.0.33'
 
 allprojects {
     sourceCompatibility = 1.7

--- a/docs/api.md
+++ b/docs/api.md
@@ -909,8 +909,8 @@ void vantiq.subscribe(String resource, String name, TypeOperation operation, Sub
 
 Name | Type | Required | Description
 :--: | :--: | :------:| -----------
-resource | String | Yes | The resource event to subscribe.  Must be either SystemResources.TOPICS.value(), SystemResources.SOURCES.value() or SystemResources.TYPES.value().
-name     | String | Yes | The resource name that identifies the specific resource event.  For topics, this is the topic name (e.g. '/my/topic/').  For sources, this is the source name.  For types, this is the data type name.
+resource | String | Yes | The resource event to subscribe.  Must be either SystemResources.TOPICS.value(), SystemResources.SOURCES.value(), SystemResources.SERVICES.values(), or SystemResources.TYPES.value().
+name     | String | Yes | The resource name that identifies the specific resource event.  For topics, this is the topic name (e.g. '/my/topic/').  For sources, this is the source name.  For services, this must be the service and event name in the form '<serviceName>/<eventName>'. For types, this is the data type name.
 operation| TypeOperation | No  | This only applies for 'types' and specifies the operation to listen to (e.g. TypeOperation.INSERT, TypeOperation.UPDATE, TypeOperation.DELETE)
 callback | SubscriptionCallback | Yes | This callback is executed when the specified events occur.
 parameters | Map<String, String>| No | Map specifying extra details about the subscription to the server. (eg: {persistent:true} to create a persistent subscription, {persistent:true: subscriptionName: 'mySub', requestId: requestId} to reconnect to a broken persistent subscription)
@@ -986,12 +986,22 @@ Create a subscription to the `MySource` source that prints out when messages arr
                      null, 
                      new StandardOutputCallback());
 
+Create a subscription to the `MyService` service's `MyEvent` service event that prints out when messages arrive at the source.
+
+    vantiq.subscribe(Vantiq.SystemResources.SERVICES.value(), 
+                     "MyService/MyEvent", 
+                     null, 
+                     new StandardOutputCallback());
+
+
 Create a subscription to the `MyDataType` type for that prints out when that type has been updated.
 
     vantiq.subscribe(Vantiq.SystemResources.TYPES.value(), 
                      "MyDataType", 
                      Vantiq.TypeOperation.UPDATE, 
                      new StandardOutputCallback());
+
+
 
 See [acknowledge](#user-content-vantiq-acknowledge) section for how to create a persistent subscription
 and acknowledge reliable events

--- a/src/main/java/io/vantiq/client/Vantiq.java
+++ b/src/main/java/io/vantiq/client/Vantiq.java
@@ -1371,7 +1371,8 @@ public class Vantiq {
      *
      * @param resource The resource whose events to subscribe.  This must be the
      *                 value of {@link Vantiq.SystemResources#TOPICS},
-     *                 {@link Vantiq.SystemResources#SOURCES}, or
+     *                 {@link Vantiq.SystemResources#SERVICES}, or
+     *                 {@link Vantiq.SystemResources#SOURCES}
      *                 {@link Vantiq.SystemResources#TYPES}.
      * @param id The id of the resource
      * @param operation Only for "types", the specific operation event to subscribe to.
@@ -1392,6 +1393,7 @@ public class Vantiq {
             path = "/" + resource + "/" + id;
         }
         if(SystemResources.SOURCES.value().equals(resource) ||
+                SystemResources.SERVICES.value().equals(resource) ||
                 SystemResources.TOPICS.value().equals(resource)) {
             if(operation != null) {
                 throw new IllegalArgumentException("Operation only support for 'types'");

--- a/src/test/java/io/vantiq/client/VantiqRequestSyncTest.java
+++ b/src/test/java/io/vantiq/client/VantiqRequestSyncTest.java
@@ -446,6 +446,21 @@ public class VantiqRequestSyncTest extends VantiqTestBase {
     }
 
     @Test
+    public void testSubscribeServiceEvent() throws Exception {
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody(new JsonObjectBuilder()
+                        .json())
+        );
+
+        vantiq.subscribe(Vantiq.SystemResources.SERVICES.value(),
+                                                    "myService/myEvent",
+                                                        null,
+                                                        null);
+    }
+
+    @Test
     public void testUploadInvalidSession() throws Exception {
         server.enqueue(new MockResponse()
                            .setHeader("Content-Type", "application/json")

--- a/src/test/java/io/vantiq/client/intg/README.md
+++ b/src/test/java/io/vantiq/client/intg/README.md
@@ -14,6 +14,9 @@ to load the artifacts into the server:
 * `project/rules/onTestPublish.vail`: A rule that persists an TestType record when an event is fired on `/test/topic`
 * `project/procedures/echo.vail`: A procedure that simply echos the input arguments
 * `project/sources/JSONPlaceholder.json`: A REMOTE source
+* `project/services/testService.json`: A service with an outbound event defined
+* `project/procedures/testService_publishToOutbound.vail`: A procedure within that service that publishes to the
+service's outbound event
 
 The following CLI command will load these into the Vantiq server:
 

--- a/src/test/resources/intgTest/procedures/testService_publishToOutbound.vail
+++ b/src/test/resources/intgTest/procedures/testService_publishToOutbound.vail
@@ -1,0 +1,3 @@
+PROCEDURE testService.publishToOutbound()
+PUBLISH {name: "outbound event", val: {breed: "English Springer"}} TO SERVICE EVENT "testService/testEvent"
+            

--- a/src/test/resources/intgTest/services/test/testPythonSDK/testService.json
+++ b/src/test/resources/intgTest/services/test/testPythonSDK/testService.json
@@ -1,0 +1,12 @@
+{
+  "active" : true,
+  "ars_relationships" : [ ],
+  "eventTypes" : {
+    "testEvent" : {
+      "direction" : "OUTBOUND",
+      "implementingEventPath" : "/topics//testService/testEvent"
+    }
+  },
+  "name" : "testService",
+  "replicationFactor" : 1
+}


### PR DESCRIPTION
Fixes #30

Adds service event subscriptions.  Test (unit & integration) updated to test this capability.