### PR TITLE
Normalize URLs with or w/o trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In Gradle,
     }
     
     dependencies {
-        compile 'io.vantiq:vantiq-sdk:1.0.32'
+        compile 'io.vantiq:vantiq-sdk:1.1.2'
     }
 
 In Maven,
@@ -25,7 +25,7 @@ In Maven,
         <dependency>
             <groupId>io.vantiq</groupId>
             <artifactId>vantiq-sdk</artifactId>
-            <version>1.0.32</version>
+            <version>1.1.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>    

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 //
 group            = 'io.vantiq'
 archivesBaseName = 'vantiq-sdk'
-version          = '1.1.1' 
+version          = '1.1.2'
 
 allprojects {
     sourceCompatibility = 1.7

--- a/src/main/java/io/vantiq/client/internal/VantiqSubscriber.java
+++ b/src/main/java/io/vantiq/client/internal/VantiqSubscriber.java
@@ -48,8 +48,14 @@ public class VantiqSubscriber extends WebSocketListener {
         }
 
         String url =
-            this.session.getServer().replace("http", "ws")
-                + "/api/v" + this.session.getApiVersion()
+            this.session.getServer().replace("http", "ws");
+        // Need to normalize trailing slash in server URI.
+        if (!(url.endsWith("/"))) {
+            url = url + "/";
+        }
+        
+        url = url
+                + "api/v" + this.session.getApiVersion()
                 + "/wsock/websocket";
         Request request = new Request.Builder().url(url).build();
 


### PR DESCRIPTION
Fixes #36 

(At least) when running integration tests, giving a server URL with a trailing slash causes all the subscribe tests to fail.  This is because the WS url subscribe uses ends up as. `http://whereever:####//api/v1...` with 2 slashes.  This results in a 401 from the server.

Changed subscribe/connect code to normalize the URL so that the server with or w/o the trailing slash is acceptable.

Since this has been there for quite a while, I suspect this is an issue primarily for (integration) tests.  But it'll save hours of debug time, so...