### PR TITLE
Add Authenticated http(s) proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In Gradle,
     }
     
     dependencies {
-        compile 'io.vantiq:vantiq-sdk:1.1.2'
+        compile 'io.vantiq:vantiq-sdk:1.2.0'
     }
 
 In Maven,
@@ -25,12 +25,12 @@ In Maven,
         <dependency>
             <groupId>io.vantiq</groupId>
             <artifactId>vantiq-sdk</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>    
 
-The Vantiq SDK for Java requires Java 7 or later.
+The Vantiq SDK for Java requires Java 8 or later.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In Gradle,
     }
     
     dependencies {
-        compile 'io.vantiq:vantiq-sdk:1.2.0'
+        compile 'io.vantiq:vantiq-sdk:1.2.1'
     }
 
 In Maven,
@@ -25,7 +25,7 @@ In Maven,
         <dependency>
             <groupId>io.vantiq</groupId>
             <artifactId>vantiq-sdk</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>    

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In Gradle,
     }
     
     dependencies {
-        compile 'io.vantiq:vantiq-sdk:1.0.32'
+        compile 'io.vantiq:vantiq-sdk:1.1.2'
     }
 
 In Maven,
@@ -25,7 +25,7 @@ In Maven,
         <dependency>
             <groupId>io.vantiq</groupId>
             <artifactId>vantiq-sdk</artifactId>
-            <version>1.0.32</version>
+            <version>1.1.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>    

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ archivesBaseName = 'vantiq-sdk'
 version          = '1.1.2'
 
 allprojects {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 repositories {
@@ -32,9 +32,9 @@ repositories {
 }
 
 ext {
-    okhttpVersion = '4.9.3'
+    okhttpVersion = '4.12.0'
     guavaVersion = '31.1-jre'
-    gsonVersion = '2.8.9'
+    gsonVersion = '2.10.1'
 }
 
 dependencies {
@@ -43,8 +43,8 @@ dependencies {
     compile "com.google.guava:guava:${guavaVersion}"
 
     testCompile "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'junit:junit:4.13.2'
+    testCompile 'org.hamcrest:hamcrest-library:2.2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 //
 group            = 'io.vantiq'
 archivesBaseName = 'vantiq-sdk'
-version          = '1.2.0'
+version          = '1.2.1'
 
 allprojects {
     sourceCompatibility = 1.8
@@ -33,7 +33,7 @@ repositories {
 
 ext {
     okhttpVersion = '4.12.0'
-    guavaVersion = '31.1-jre'
+    guavaVersion = '32.1.3-jre'
     gsonVersion = '2.10.1'
 }
 
@@ -45,6 +45,10 @@ dependencies {
     testCompile "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.hamcrest:hamcrest-library:2.2'
+}
+
+tasks.withType(Test) {
+    jvmArgs += ['--add-opens', 'java.base/jdk.internal.loader=ALL-UNNAMED']
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 //
 group            = 'io.vantiq'
 archivesBaseName = 'vantiq-sdk'
-version          = '1.1.2'
+version          = '1.2.0'
 
 allprojects {
     sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 //
 group            = 'io.vantiq'
 archivesBaseName = 'vantiq-sdk'
-version          = '1.1.1' 
+version          = '1.1.2'
 
 allprojects {
     sourceCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,16 @@ task intgTest(type:Test) {
     systemProperties['username'] = System.getProperty('username')
     systemProperties['password'] = System.getProperty('password')
     systemProperties['token'] = System.getProperty('token')
+    def useProxy = System.getProperty("proxyHost")
+    if (useProxy) {
+        def scheme = new URI(System.getProperty('server')).getScheme()
+        systemProperties["${scheme}.proxyHost"] = System.getProperty('proxyHost')
+        systemProperties["${scheme}.proxyPort"] = System.getProperty('proxyPort')
+        systemProperties["${scheme}.proxyUser"] = System.getProperty('proxyUser')
+        systemProperties["${scheme}.proxyPassword"] = System.getProperty('proxyPassword')
+        systemProperties["${scheme}.nonProxyHosts"] = ""
+    }
+
     useJUnit {
         includeCategories 'io.vantiq.client.intg.IntegrationTests'
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,15 +109,16 @@ This class exposes the [Vantiq REST API](https://dev.vantiq.com/docs/system/api/
 ### Signature
 
 ```java
-Vantiq vantiq = new Vantiq(String server[, int apiVersion])
+Vantiq vantiq = new Vantiq(String server[, int apiVersion, [Authenticator proxyAuthentcator]])
 ```
 
 ### Option Parameters
 
-Name | Type | Required | Description
-:--: | :--: | :------:| -----------
-server | String | Yes | The Vantiq server URL to connect to, e.g. `https://dev.vantiq.com`
-apiVersion | int | No | The version of the API to use.  Defaults to the latest.
+| Name               | Type                  | Required | Description                                                                                                                                                                                                                                                                                                                          |
+|--------------------|-----------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| server             | String                | Yes      | The Vantiq server URL to connect to, e.g. `https://dev.vantiq.com`                                                                                                                                                                                                                                                                   |
+| apiVersion         | int                   | No       | The version of the API to use.  Defaults to the latest.                                                                                                                                                                                                                                                                              |
+| proxyAuthenticator | okhttp3.Authenticator | No       | An Authenticator to use when an http proxy requires authentication. This is required only when BASIC user/password authentication is insufficient. The SDK will provide a built-in authenticator using the _scheme_`.proxyUser` and _scheme_`.proxyPassword` (where _scheme_ is the scheme from the server URL (`http` or `https`)). |
 
 ### Returns
 

--- a/src/main/java/io/vantiq/client/Vantiq.java
+++ b/src/main/java/io/vantiq/client/Vantiq.java
@@ -2,13 +2,11 @@ package io.vantiq.client;
 
 import com.google.gson.*;
 import io.vantiq.client.internal.VantiqSession;
-import okhttp3.Response;
 
 import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import okhttp3.Authenticator;
+import okhttp3.Response;
 
 /**
  * Vantiq SDK for Java/Android API
@@ -92,7 +90,22 @@ public class Vantiq {
     public Vantiq(String server, int apiVersion) {
         this.session = new VantiqSession(server, apiVersion);
     }
-
+    
+    /**
+     * Constructs a Vantiq SDK instance against a specific Vantiq server
+     * URL using a specific REST API version.
+     * </p>
+     * The proxyAuthenticator is only required when the proxy requires authentication other than Basic user and
+     * password. The internal authenticator will provide those as required, based on the Java standard properties.
+     *
+     * @param server                The URL of the Vantiq server
+     * @param apiVersion            The REST API version to use
+     * @param proxyAuthenticator    okhttp3.Authenticator Used to authenticate with a network proxy.
+     */
+    public Vantiq(String server, int apiVersion, Authenticator proxyAuthenticator) {
+        this.session = new VantiqSession(server, apiVersion, proxyAuthenticator);
+    }
+    
     /**
      * Constructs a Vantiq SDK instance against a specific Vantiq server
      * using the latest version of the API.
@@ -102,7 +115,21 @@ public class Vantiq {
     public Vantiq(String server) {
         this.session = new VantiqSession(server);
     }
-
+    
+    /**
+     * Constructs a Vantiq SDK instance against a specific Vantiq server
+     * using the latest version of the API.
+     * </p>
+     * The proxyAuthenticator is only required when the proxy requires authentication other than Basic user and
+     * password. The internal authenticator will provide those as required, based on the Java standard properties.
+     *
+     * @param server                The URL of the Vantiq server
+     * @param proxyAuthenticator    okhttp3.Authenticator Used to authenticate with a network proxy.
+     */
+    public Vantiq(String server, Authenticator proxyAuthenticator) {
+        this.session = new VantiqSession(server, proxyAuthenticator);
+    }
+    
     /**
      * Returns if this Vantiq instance has been successfully
      * authenticated with the Vantiq server instance.

--- a/src/main/java/io/vantiq/client/Vantiq.java
+++ b/src/main/java/io/vantiq/client/Vantiq.java
@@ -94,7 +94,7 @@ public class Vantiq {
     /**
      * Constructs a Vantiq SDK instance against a specific Vantiq server
      * URL using a specific REST API version.
-     * </p>
+     * <p>
      * The proxyAuthenticator is only required when the proxy requires authentication other than Basic user and
      * password. The internal authenticator will provide those as required, based on the Java standard properties.
      *
@@ -119,7 +119,7 @@ public class Vantiq {
     /**
      * Constructs a Vantiq SDK instance against a specific Vantiq server
      * using the latest version of the API.
-     * </p>
+     * <p>
      * The proxyAuthenticator is only required when the proxy requires authentication other than Basic user and
      * password. The internal authenticator will provide those as required, based on the Java standard properties.
      *

--- a/src/main/java/io/vantiq/client/internal/VantiqSession.java
+++ b/src/main/java/io/vantiq/client/internal/VantiqSession.java
@@ -20,7 +20,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import okhttp3.*;
+
+import okhttp3.Authenticator;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okio.ByteString;
 
 /**
@@ -461,7 +474,6 @@ public class VantiqSession {
                     {
                         this.idToken = idToken.getAsString();
                     }
-
                 }
             }
         }

--- a/src/main/java/io/vantiq/client/internal/VantiqSession.java
+++ b/src/main/java/io/vantiq/client/internal/VantiqSession.java
@@ -96,7 +96,10 @@ public class VantiqSession {
         // If a proxy authenticator has been provided, set up our client to use it.
         if (needProxyAuth) {
             builder.proxySelector(ProxySelector.getDefault());
-            builder.proxyAuthenticator(this.proxyAuthenticator);
+            // if a proxy authenticator has been provided, use it.  Otherwise, assume things will work out.
+            if (this.proxyAuthenticator != null) {
+                builder.proxyAuthenticator(this.proxyAuthenticator);
+            }
         }
         this.client = builder.build();
     }

--- a/src/main/java/io/vantiq/client/internal/VantiqSession.java
+++ b/src/main/java/io/vantiq/client/internal/VantiqSession.java
@@ -3,23 +3,25 @@ package io.vantiq.client.internal;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import io.vantiq.client.ResponseHandler;
 import io.vantiq.client.SubscriptionCallback;
 import io.vantiq.client.VantiqError;
 import io.vantiq.client.VantiqResponse;
-import okhttp3.*;
-import okio.ByteString;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import okio.ByteString;
 
 /**
  * Internal class that manages the authenticated access and interface
@@ -37,6 +39,8 @@ public class VantiqSession {
 
     private String   server;
     private int      apiVersion;
+    private Authenticator proxyAuthenticator = null;
+    private Proxy proxy = null;
     private boolean  authenticated;
     private String   accessToken;
     private String   idToken;
@@ -51,11 +55,20 @@ public class VantiqSession {
     public VantiqSession(String server) {
         this(server, DEFAULT_API_VERSION);
     }
-
+    
+    public VantiqSession(String server, Authenticator proxyAuthenticator) {
+        this(server, DEFAULT_API_VERSION, proxyAuthenticator);
+    }
+    
     public VantiqSession(String server, int apiVersion) {
+        this(server, apiVersion, null);
+    }
+    public VantiqSession(String server, int apiVersion, Authenticator proxyAuthenticator) {
         super();
         this.server     = server;
         this.apiVersion = apiVersion;
+        this.proxyAuthenticator = proxyAuthenticator;
+    
         createClient();
     }
 
@@ -69,15 +82,57 @@ public class VantiqSession {
         //  See https://stackoverflow.com/questions/46807237/protocolexception-expected-status-header-not-present
         //  See https://stackoverflow.com/questions/49643383/http-2-protocol-not-working-with-okhttp
         //
-        List<Protocol> protocols = new ArrayList<Protocol>();
+        List<Protocol> protocols = new ArrayList<>();
         protocols.add(Protocol.HTTP_1_1);
         
-        this.client = new OkHttpClient.Builder()
+        boolean needProxyAuth = setupProxyAuthentication();
+    
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
             .readTimeout(this.readTimeout, TimeUnit.MILLISECONDS)
             .writeTimeout(this.writeTimeout, TimeUnit.MILLISECONDS)
             .connectTimeout(this.connectTimeout, TimeUnit.MILLISECONDS)
-            .protocols(protocols)
-            .build();
+            .protocols(protocols);
+        
+        // If a proxy authenticator has been provided, set up our client to use it.
+        if (needProxyAuth) {
+            builder.proxySelector(ProxySelector.getDefault());
+            builder.proxyAuthenticator(this.proxyAuthenticator);
+        }
+        this.client = builder.build();
+    }
+    
+    private boolean setupProxyAuthentication() {
+        if (proxyAuthenticator != null) {
+            return true;
+        } else {
+            try {
+                URI serverUri = new URI(this.server);
+                // ask Java if we're using a proxy.
+                List<Proxy> proxies = ProxySelector.getDefault().select(serverUri);
+                if (proxies.size() == 0 || (proxies.size() == 1  && proxies.get(0).type() == Proxy.NO_PROXY.type())) {
+                    return false;
+                } else {
+                    // Here, we'll need to define ourselves a simple authenticator
+                    String scheme = serverUri.getScheme();
+                    String proxyUser = System.getProperty(scheme.toLowerCase() + ".proxyUser");
+                    String proxyPw = System.getProperty(scheme.toLowerCase() + ".proxyPassword");
+                    if (proxyUser != null && proxyPw != null) {
+                        this.proxyAuthenticator = (route, response) -> {
+                            String credential = Credentials.basic(proxyUser, proxyPw);
+                            return response.request().newBuilder()
+                                           .header("Proxy-Authorization", credential)
+                                           .build();
+                        };
+                    } else {
+                        // If we can't find credentials, fall back to the default Java-provided one.
+                        this.proxyAuthenticator = Authenticator.JAVA_NET_AUTHENTICATOR;
+                    }
+                    return true;
+                }
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/vantiq/client/internal/VantiqSubscriber.java
+++ b/src/main/java/io/vantiq/client/internal/VantiqSubscriber.java
@@ -48,8 +48,14 @@ public class VantiqSubscriber extends WebSocketListener {
         }
 
         String url =
-            this.session.getServer().replace("http", "ws")
-                + "/api/v" + this.session.getApiVersion()
+            this.session.getServer().replace("http", "ws");
+        // Need to normalize trailing slash in server URI.
+        if (!(url.endsWith("/"))) {
+            url = url + "/";
+        }
+        
+        url = url
+                + "api/v" + this.session.getApiVersion()
                 + "/wsock/websocket";
         Request request = new Request.Builder().url(url).build();
 

--- a/src/test/java/io/vantiq/client/UnitTestSubscriptionCallback.java
+++ b/src/test/java/io/vantiq/client/UnitTestSubscriptionCallback.java
@@ -69,7 +69,20 @@ public class UnitTestSubscriptionCallback implements SubscriptionCallback {
             wait(timeout);
         }
     }
-
+    
+    public synchronized void waitForConnection(int timeout) throws InterruptedException {
+        long limitTime = System.currentTimeMillis() + timeout;
+        long now = limitTime;
+        while (!this.connected && now <= limitTime) {
+            wait(timeout);
+            now = System.currentTimeMillis();
+        }
+    }
+    
+    public synchronized void waitForConnection() throws InterruptedException {
+        waitForConnection(2000);
+    }
+    
     public synchronized void waitForCompletion() throws InterruptedException {
         waitForCompletion(2000);
     }

--- a/src/test/java/io/vantiq/client/intg/README.md
+++ b/src/test/java/io/vantiq/client/intg/README.md
@@ -34,7 +34,7 @@ The integration tests also need Java system properties set before they can run. 
 `server`, e.g. `https://dev.vantiq.com`. Authentication must be provided through either username and password or a
 token. The username and password can be placed in `username` and `password`, or the token can be provided through
 `token`. To set these properties for Gradle add `-D<variable>=<value>` for each property. For IntelliJ put the same in
-the VM options section of the Ron/Debug configurations.
+the VM options section of the Run/Debug configurations.
 
 For example:  
 

--- a/src/test/java/io/vantiq/client/intg/README.md
+++ b/src/test/java/io/vantiq/client/intg/README.md
@@ -38,4 +38,39 @@ the VM options section of the Ron/Debug configurations.
 
 For example:  
 
-    %  ./gradlew intgtest -Dserver=http://localhost:8080 -Dusername=aaaa -Dpassword=mypwd    
+    %  ./gradlew intgtest -Dserver=http://localhost:8080 -Dusername=aaaa -Dpassword=mypwd 
+
+### HTTP(S) Proxy Integration Tests
+
+To run the integration tests verifying that they work with a network proxy, you will need
+to add a few more properties to the `gradle` command line.
+
+Assume that we have a proxy running on the local machine (port 3128) that does NOT
+require authentication. To run the integration tests using that configuration, use
+
+```shell
+%  ./gradlew intgtest -Dserver=http://localhost:8080 -Dusername=aaaa -Dpassword=mypwd \
+    -DproxyHost=localhost -DproxyPort=3128
+```
+
+If you have the same configuration but it does require BASIC user/password authentication, use
+the following command.
+
+```shell
+%  ./gradlew intgtest -Dserver=http://localhost:8080 -Dusername=aaaa -Dpassword=mypwd \
+    -DproxyHost=localhost -DproxyPort=3128 -DproxyUser=proxyuser -DproxyPassword=proxypwd
+```
+
+where _proxyuser_ and _proxypwd_ are replaced by the appropriate
+values for your proxy configuration.
+
+(Note -- for running the tests, the `build.gradle` file will set these
+properties using the server's scheme.  That is, the executing test
+will see `http.proxyUser` if the `server` property is `http://...`.)
+
+Note that you will need to adjust the properties used to reflect the server URL scheme
+(`http.proxyUser` for a server URL of `http://localhost:8080`). That is, for IntelliJ,
+put the adjusted values in the VM options section of the Ron/Debug configurations.
+
+The `src/test/resources/squidProxy` directory has sample files for configuration of a Squid proxy (v5.9).
+These are just samples -- there is no requirement to make use of them.

--- a/src/test/java/io/vantiq/client/intg/VantiqIntegrationTest.java
+++ b/src/test/java/io/vantiq/client/intg/VantiqIntegrationTest.java
@@ -563,7 +563,7 @@ public class VantiqIntegrationTest {
         // These types of subscriptions may be a multi-step process where by > 1 message is required to complete the
         // connection.  callback.waitForCompletion() just waits until some message arrives, not necessarily the
         // connection message.  callback.waitForConnection() will loop (up to the specified (or default) timeout
-        // period until it sees that the connection status is satisfied.  If not (that is, timeout occurs), then it
+        // period) until it sees that the connection status is satisfied.  If not (that is, timeout occurs), then it
         // will return and the assertThat will detect the error state.
         //
         // Note that this is more prevalent (but not exclusive) when the path to the server is more "complicated."
@@ -632,7 +632,7 @@ public class VantiqIntegrationTest {
         // These types of subscriptions may be a multi-step process where by > 1 message is required to complete the
         // connection.  callback.waitForCompletion() just waits until some message arrives, not necessarily the
         // connection message.  callback.waitForConnection() will loop (up to the specified (or default) timeout
-        // period until it sees that the connection status is satisfied.  If not (that is, timeout occurs), then it
+        // period) until it sees that the connection status is satisfied.  If not (that is, timeout occurs), then it
         // will return and the assertThat will detect the error state.
         //
         // Note that this is more prevalent (but not exclusive) when the path to the server is more "complicated."
@@ -722,7 +722,7 @@ public class VantiqIntegrationTest {
         // These types of subscriptions may be a multi-step process where by > 1 message is required to complete the
         // connection.  callback.waitForCompletion() just waits until some message arrives, not necessarily the
         // connection message.  callback.waitForConnection() will loop (up to the specified (or default) timeout
-        // period until it sees that the connection status is satisfied.  If not (that is, timeout occurs), then it
+        // period) until it sees that the connection status is satisfied.  If not (that is, timeout occurs), then it
         // will return and the assertThat will detect the error state.
         //
         // Note that this is more prevalent (but not exclusive) when the path to the server is more "complicated."

--- a/src/test/resources/squidProxy/squid.conf.no_authentication
+++ b/src/test/resources/squidProxy/squid.conf.no_authentication
@@ -1,0 +1,104 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+#http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+#http_access allow localhost manager
+http_access deny manager
+
+# This default configuration only allows localhost requests because a more
+# permissive Squid installation could introduce new attack vectors into the
+# network by proxying external TCP connections to unprotected services.
+http_access allow localhost
+
+# The two deny rules below are unnecessary in this default configuration
+# because they are followed by a "deny all" rule. However, they may become
+# critically important when you start allowing external requests below them.
+
+# Protect web applications running on the same server as Squid. They often
+# assume that only local users can access them at "localhost" ports.
+#http_access deny to_localhost
+
+# Protect cloud servers that provide local users with sensitive info about
+# their server via certain well-known link-local (a.k.a. APIPA) addresses.
+http_access deny to_linklocal
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# For example, to allow access from your local networks, you may uncomment the
+# following rule (and/or add rules that match your definition of "local"):
+# http_access allow localnet
+
+## fhc -- add websocket support
+http_upgrade_request_protocols OTHER allow all
+
+## fhc -- add authentication requirement. Need to have defined passwd file 
+## for apache code -- see
+##  https://webhostinggeeks.com/howto/configure-user-authentication-squid-proxy-server
+## for details.  Note that tweaking most of these parameters requires a squid
+## restart. 'squid -k reconfigure' is not sufficient.
+
+# Require user/pass to access squid
+# auth_param basic program /usr/local/opt/squid/libexec/basic_ncsa_auth /usr/local/opt/squid/.bottle/etc/passwd
+# auth_param basic children 5 startup=5 idle=1
+# auth_param basic credentialsttl 2 hours
+
+# acl auth_users proxy_auth REQUIRED
+# http_access allow auth_users
+
+## End of fhc additions for authenticated proxy requirements
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /usr/local/var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /usr/local/var/cache/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320

--- a/src/test/resources/squidProxy/squid.conf.require_authentication
+++ b/src/test/resources/squidProxy/squid.conf.require_authentication
@@ -1,0 +1,104 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+#http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+#http_access allow localhost manager
+http_access deny manager
+
+# This default configuration only allows localhost requests because a more
+# permissive Squid installation could introduce new attack vectors into the
+# network by proxying external TCP connections to unprotected services.
+#http_access allow localhost
+
+# The two deny rules below are unnecessary in this default configuration
+# because they are followed by a "deny all" rule. However, they may become
+# critically important when you start allowing external requests below them.
+
+# Protect web applications running on the same server as Squid. They often
+# assume that only local users can access them at "localhost" ports.
+#http_access deny to_localhost
+
+# Protect cloud servers that provide local users with sensitive info about
+# their server via certain well-known link-local (a.k.a. APIPA) addresses.
+http_access deny to_linklocal
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# For example, to allow access from your local networks, you may uncomment the
+# following rule (and/or add rules that match your definition of "local"):
+# http_access allow localnet
+
+## fhc -- add websocket support
+http_upgrade_request_protocols OTHER allow all
+
+## fhc -- add authentication requirement. Need to have defined passwd file 
+## for apache code -- see
+##  https://webhostinggeeks.com/howto/configure-user-authentication-squid-proxy-server
+## for details.  Note that tweaking most of these parameters requires a squid
+## restart. 'squid -k reconfigure' is not sufficient.
+
+# Require user/pass to access squid
+auth_param basic program /usr/local/opt/squid/libexec/basic_ncsa_auth /usr/local/opt/squid/.bottle/etc/passwd
+auth_param basic children 5 startup=5 idle=1
+auth_param basic credentialsttl 2 hours
+
+acl auth_users proxy_auth REQUIRED
+http_access allow auth_users
+
+## End of fhc additions for authenticated proxy requirements
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /usr/local/var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /usr/local/var/cache/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320


### PR DESCRIPTION
Fixes #38 
Fixes #36

Addresses [AHA CP-151](https://vantiq.aha.io/features/CP-151)

Add support for http(s) proxy with/without authentication.  

If the VantiqSession sees a Java property of _scheme_`.proxyHost`, configure the _okhttp3_ client to use proxies.  If _scheme_`.proxyUser` and _scheme_`.proxyPassword` are provided, set up an OKHttp3.Authenticator to provide a the BASIC authentication required for the proxy. (_scheme_ is the scheme from the Vantiq server URL.)

We allow the user to provide their own Authenticator (new last parameter on the Vantiq object constructor) for cases where our BASIC mechanism is insufficient (_e.g._, local devices, biometric things.)

Update docs appropriately.  Update integration testing docs.  Adds Squid proxy configuration for a proxy both with and without authentication required. There is no requirement to use the squid proxy, but I did & don't want to lose the configurations!  Getting all that to work was the hardest part of this project!

Cleaned up a few things.  Incorporated forgotten PR #37 that handled extraneous /'s at the end of the server URL (which I'll close).  Updated doc & build to use Java 1.8 since that's a requirement for (at least) okhttp3.  Updated versions for a few things to bring into the modern era.

Updated version to 1.2.0 to reflect API addition & Java version "change."  (In practice, 1.8 was required anyway since that's what some of our dependencies required, but it was "less official.")