### PR TITLE
Minor test tweaks for Java SDK

### DIFF
--- a/src/test/java/io/vantiq/client/intg/README.md
+++ b/src/test/java/io/vantiq/client/intg/README.md
@@ -11,7 +11,7 @@ The following project must be loaded into an existing Vantiq server for the inte
 to load the artifacts into the server:
 
 * `project/types/TestType.json`: A data type for testing
-* `project/rules/onTestPublish.vail`: A rule that persists an TestType record when an event is fired on `/test/topic`
+* `project/rules/onSDKTestPublish.vail`: A rule that persists an TestType record when an event is fired on `/test/topic`
 * `project/procedures/echo.vail`: A procedure that simply echos the input arguments
 * `project/sources/JSONPlaceholder.json`: A REMOTE source
 * `project/services/testService.json`: A service with an outbound event defined

--- a/src/test/resources/intgTest/rules/onSDKTestPublish.vail
+++ b/src/test/resources/intgTest/rules/onSDKTestPublish.vail
@@ -1,4 +1,4 @@
-RULE onTestPublish
+RULE onSDKTestPublish
 
 WHEN PUBLISH OCCURS ON "/test/topic" AS event
 

--- a/src/test/resources/intgTest/rules/sdkServicePublish.vail
+++ b/src/test/resources/intgTest/rules/sdkServicePublish.vail
@@ -1,4 +1,4 @@
-RULE servicePublish
+RULE sdkServicePublish
 
 WHEN EVENT OCCURS ON "/services/testService/inboundTestEvent" AS event
 


### PR DESCRIPTION
No issue reported.

Some diagnostic & test fixes.  Increase wait time for running over home network.  Skip tests when VA server types not available.  Add a few diagnostic changes.

Change some rule names so that a namespace with both python SDK & java SDK resources don't conflict.